### PR TITLE
bug: The Verify.MicrosoftLogging does not work well after updating to version 4 when it's used WebApplicationFactory together.

### DIFF
--- a/src/Verify.MicrosoftLogging.sln
+++ b/src/Verify.MicrosoftLogging.sln
@@ -19,6 +19,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\readme.md = ..\readme.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sample", "Sample", "{407403A7-385F-4E07-AB79-F376E9E9272D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApplication", "sample\WebApplication\WebApplication.csproj", "{1694E302-0830-45EE-BCEA-C3A613CD884E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestProject", "sample\TestProject\TestProject.csproj", "{56132CE0-CE2C-4E55-B684-CD97929C67F3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,9 +39,21 @@ Global
 		{76FE87D9-EF6B-4D31-99F2-7099C719AE99}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76FE87D9-EF6B-4D31-99F2-7099C719AE99}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76FE87D9-EF6B-4D31-99F2-7099C719AE99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1694E302-0830-45EE-BCEA-C3A613CD884E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1694E302-0830-45EE-BCEA-C3A613CD884E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1694E302-0830-45EE-BCEA-C3A613CD884E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1694E302-0830-45EE-BCEA-C3A613CD884E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56132CE0-CE2C-4E55-B684-CD97929C67F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56132CE0-CE2C-4E55-B684-CD97929C67F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56132CE0-CE2C-4E55-B684-CD97929C67F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56132CE0-CE2C-4E55-B684-CD97929C67F3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1694E302-0830-45EE-BCEA-C3A613CD884E} = {407403A7-385F-4E07-AB79-F376E9E9272D}
+		{56132CE0-CE2C-4E55-B684-CD97929C67F3} = {407403A7-385F-4E07-AB79-F376E9E9272D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0B94980-5385-4EC6-A0EE-C9A191DDFC05}

--- a/src/sample/TestProject/CustomWebApplicationFactory.cs
+++ b/src/sample/TestProject/CustomWebApplicationFactory.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using VerifyTests.MicrosoftLogging;
+
+namespace TestProject
+{
+    internal class CustomWebApplicationFactory : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder) => ConfigureVerifyLoggingV4(builder);
+
+        void ConfigureVerifyLoggingV4(IWebHostBuilder builder) =>
+            builder.ConfigureTestServices(services =>
+            {
+                services.AddLogging(options =>
+                {
+                    options.ClearProviders();
+
+                    Recording.Start();
+                    var verifyLoggerProvider = new RecordingProvider();
+                    options.AddProvider(verifyLoggerProvider);
+                });
+            });
+    }
+}

--- a/src/sample/TestProject/Initialization.cs
+++ b/src/sample/TestProject/Initialization.cs
@@ -1,0 +1,10 @@
+using System.Runtime.CompilerServices;
+
+namespace TestProject
+{
+    public static class Initialization
+    {
+        [ModuleInitializer]
+        public static void Initialize() => VerifyMicrosoftLogging.Initialize();
+    }
+}

--- a/src/sample/TestProject/TestProject.csproj
+++ b/src/sample/TestProject/TestProject.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Verify" Version="23.2.2" />
+    <PackageReference Include="Verify.Xunit" Version="23.2.2" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Verify.MicrosoftLogging\Verify.MicrosoftLogging.csproj" />
+    <ProjectReference Include="..\WebApplication\WebApplication.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/sample/TestProject/WeatherforecastTests.cs
+++ b/src/sample/TestProject/WeatherforecastTests.cs
@@ -1,0 +1,21 @@
+namespace TestProject
+{
+    public class WeatherforecastTests
+    {
+        readonly CustomWebApplicationFactory applicationFactory = new();
+
+
+        [Fact(Timeout = 3000)] // 👈 Needs this timeout because the Exception is throw "'System.Exception' in Verify.dll" and the run stay frezzing on "client.GetAsync"
+        public async Task Test1()
+        {
+            // Arrange
+            var client = applicationFactory.CreateClient();
+
+            // Act
+            var result = await client.GetAsync("/weatherforecast");
+
+            // Assert
+            await Verify(new { result.StatusCode });
+        }
+    }
+}

--- a/src/sample/WebApplication/Program.cs
+++ b/src/sample/WebApplication/Program.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", ([FromServices] ILogger< WeatherForecast> logger) =>
+{
+    logger.LogInformation("Starting...");
+
+    var forecast = Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+
+    logger.LogInformation("Total found: {count}", forecast.Length);
+
+    return forecast;
+});
+
+app.Run();
+
+record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/src/sample/WebApplication/Properties/Assembly.cs
+++ b/src/sample/WebApplication/Properties/Assembly.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("TestProject")]

--- a/src/sample/WebApplication/Properties/launchSettings.json
+++ b/src/sample/WebApplication/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:50262",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "http://localhost:5206",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/sample/WebApplication/WebApplication.csproj
+++ b/src/sample/WebApplication/WebApplication.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Verify.MicrosoftLogging\Verify.MicrosoftLogging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/sample/WebApplication/WebApplication.http
+++ b/src/sample/WebApplication/WebApplication.http
@@ -1,0 +1,6 @@
+@WebApplication_HostAddress = http://localhost:5206
+
+GET {{WebApplication_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/src/sample/WebApplication/appsettings.Development.json
+++ b/src/sample/WebApplication/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/sample/WebApplication/appsettings.json
+++ b/src/sample/WebApplication/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
The `Verify.MicrosoftLogging` does not work well after updating to version 4 when it's used `WebApplicationFactory` together.

When run, the exception below is thrown:

```
System.Exception: 'Recording.Start must be called before Recording.Add'
System.Exception
  HResult=0x80131500
  Message=Recording.Start must be called before Recording.Add
  Source=Verify
  StackTrace:
   at VerifyTests.Recording.CurrentState(String caller) in /_/src/Verify/Recording/Recording.cs:line 70
```

![image](https://github.com/VerifyTests/Verify.MicrosoftLogging/assets/11078528/13656f9c-4843-4bb8-8fa0-96b4ab906a12)
